### PR TITLE
Move some functionality into an i18n utility module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ import en from './en';
 const mnoga = new Mnoga();
 
 // Set translations for japanese and english.
-mnoga.setTranslations('ja', ja);
-mnoga.setTranslations('en', en);
+mnoga.setPhrases('ja', ja);
+mnoga.setPhrases('en', en);
 
 // Set the fallback locale. `en` is already the default.
 mnoga.setFallback('en');
@@ -126,7 +126,7 @@ tag to see if there are any reasonable matches to fallback on.
 ```
 const mnoga = new Mnoga();
 
-mnoga.setTranslations('zh', {});
+mnoga.setPhrases('zh', {});
 
 // If the locale contains script and region, it will fallback and choose zh.
 mnoga.setLocale('zh-Hant-HK');
@@ -148,8 +148,8 @@ as the officially supported locale.
 ```
 const mnoga = new Mnoga();
 
-mnoga.setTranslations('zh-Hans', {});
-mnoga.setTranslations('zh-Hant', {});
+mnoga.setPhrases('zh-Hans', {});
+mnoga.setPhrases('zh-Hant', {});
 
 // Mainland china should use simplified Chinese.
 mnoga.setAlias(['zh', 'zh-CN'], 'zh-Hans');
@@ -172,8 +172,8 @@ British English, but also want users from Australia to use British English.
 ```
 const mnoga = new Mnoga();
 
-mnoga.setTranslations('en-US', {});
-mnoga.setTranslations('en-GB', {});
+mnoga.setPhrases('en-US', {});
+mnoga.setPhrases('en-GB', {});
 
 mnoga.setAlias('en-AU', 'en-GB');
 
@@ -190,14 +190,14 @@ cause the method to be executed.
 ```
 const mnoga = new Mnoga();
 
-// Will update the title whenever locale or translations change.
+// Will update the title whenever locale or phrases change.
 const render = () => {
   document.head.title = mnoga.t('title');
 };
 
 // Set some translations.
-mnoga.setTranslations('en', { title: 'English Homepage' });
-mnoga.setTranslations('ja', { title: '日本語ホムページ' });
+mnoga.setPhrases('en', { title: 'English Homepage' });
+mnoga.setPhrases('ja', { title: '日本語ホムページ' });
 
 // Returns an unsubscribe method that can be called if we want to stop listening for changes.
 const unsubscribe = mnoga.subscribe(update);
@@ -207,7 +207,7 @@ mnoga.setLocale('ja');
 console.log(document.head.title); // '日本語ホムページ'
 
 // Changing the translations will call subscribe.
-mnoga.setTranslations('ja', { title: '新しい日本語ホムページ' });
+mnoga.setPhrases('ja', { title: '新しい日本語ホムページ' });
 console.log(document.head.title); // '新しい日本語ホムページ'
 ```
 
@@ -234,6 +234,43 @@ const rulesForEnglish = (count) => {
 
 // Sets this rule for English.
 mnoga.setRule('en', rulesForEnglish);
+```
+
+## Utilities
+
+Utility methods are also provided if you want to maintain your own state.
+
+```
+import { getCanonicalLocales, lookupLocale, lookupPhrase } from 'mnoga/utils/i18n';
+
+// Returns a canonical format of a locale or multiple locales.
+getCanonicalLocales('EN-US');                       // ['en-US']
+getCanonicalLocales(['EN-US', 'ZH-HANT-TW', 'Fr']); // ['en-US', 'zh-Hant-TW', 'fr']
+
+// Gets a preferred locale.
+const supportedLocales = ['zh-Hant', 'zh-Hans', 'pt', 'en'];
+lookupLocale('zh-Hant-TW', supportedLocales);            // zh-Hant
+lookupLocale('zh-Hans-CN', supportedLocales);            // zh-Hans
+lookupLocale(['pt-BR', 'en'], supportedLocales);         // pt
+lookupLocale('zh', supportedLocales, { zh: 'zh-Hans' }); // zh-Hans
+
+// Lookup a phrase. Be sure to canonicalize the locales.
+const phrases = {
+  en: {
+    context_1: {
+      context_2: 'English Phrase',
+    },
+  },
+  ja: {
+    context_1: {
+      context_2: 'Japanese Phrase',
+    },
+  },
+};
+
+lookupPhrase({ key: 'context_1.context_2', locales: ['ja'], phrases });       // Japanese Phrase
+lookupPhrase({ key: 'context_1.context_2', locales: ['fr', 'en'], phrases }); // English Phrase
+lookupPhrase({ key: 'context_1.context_2', locales: ['pt'], phrases });       // context_1.context_2
 ```
 
 ## Further Reading

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -6,7 +6,7 @@ import { PluralCategory } from './utils/pluralization';
 describe('Mnoga', () => {
   let mnoga: Mnoga;
 
-  const EN_TRANSLATIONS = {
+  const EN_PHRASES = {
     app: {
       pluralize: {
         one: '%{count} cat',
@@ -17,7 +17,7 @@ describe('Mnoga', () => {
     },
   };
 
-  const JA_TRANSLATIONS = {
+  const JA_PHRASES = {
     app: {
       pluralize: '%{count}匹',
       label: 'アップストリング',
@@ -37,8 +37,8 @@ describe('Mnoga', () => {
 
   beforeEach(() => {
     mnoga = new Mnoga();
-    mnoga.setTranslations('en', EN_TRANSLATIONS);
-    mnoga.setTranslations('ja', JA_TRANSLATIONS);
+    mnoga.setPhrases('en', EN_PHRASES);
+    mnoga.setPhrases('ja', JA_PHRASES);
   });
 
   describe('deleteAlias', () => {
@@ -71,10 +71,10 @@ describe('Mnoga', () => {
     });
   });
 
-  describe('deleteTranslations', () => {
-    it('deletes the translations', () => {
+  describe('deletePhrases', () => {
+    it('deletes the phrases', () => {
       const before = mnoga.t('app.pluralize', { count: 1 });
-      mnoga.deleteTranslations('en');
+      mnoga.deletePhrases('en');
       const after = mnoga.t('app.pluralize', { count: 1 });
 
       expect(before).to.equal('1 cat');
@@ -82,11 +82,11 @@ describe('Mnoga', () => {
     });
 
     it('calls subscriber', () => {
-      callsSubscribers(() => mnoga.deleteTranslations('en'), true);
+      callsSubscribers(() => mnoga.deletePhrases('en'), true);
     });
 
     it('does not call subscriber', () => {
-      callsSubscribers(() => mnoga.deleteTranslations('zh-yue'), false);
+      callsSubscribers(() => mnoga.deletePhrases('zh-yue'), false);
     });
   });
 
@@ -124,23 +124,23 @@ describe('Mnoga', () => {
     });
   });
 
-  describe('hasTranslationsForLocale', () => {
+  describe('hasPhrasesForLocale', () => {
     it('returns true', () => {
-      expect(mnoga.hasTranslationsForLocale('en')).to.equal(true);
+      expect(mnoga.hasPhrasesForLocale('en')).to.equal(true);
     });
 
-    it('returns true after setting a translation', () => {
-      mnoga.setTranslations('zh-yue', {});
-      expect(mnoga.hasTranslationsForLocale('zh-yue')).to.equal(true);
+    it('returns true after setting a phrase', () => {
+      mnoga.setPhrases('zh-yue', {});
+      expect(mnoga.hasPhrasesForLocale('zh-yue')).to.equal(true);
     });
 
     it('returns false', () => {
-      expect(mnoga.hasTranslationsForLocale('zh-yue')).to.equal(false);
+      expect(mnoga.hasPhrasesForLocale('zh-yue')).to.equal(false);
     });
 
-    it('returns false after removing translation', () => {
-      mnoga.deleteTranslations('en');
-      expect(mnoga.hasTranslationsForLocale('en')).to.equal(false);
+    it('returns false after removing phrase', () => {
+      mnoga.deletePhrases('en');
+      expect(mnoga.hasPhrasesForLocale('en')).to.equal(false);
     });
   });
 
@@ -202,46 +202,46 @@ describe('Mnoga', () => {
     });
 
     it('normalizes locale', () => {
-      mnoga.setTranslations('zh-Hant-HK', {});
+      mnoga.setPhrases('zh-Hant-HK', {});
       mnoga.setLocale('ZH-hANT-hk');
       expect(mnoga.getLocale()).to.equal('zh-Hant-HK');
     });
 
     it('falls back to script when given a tag containing script and region', () => {
-      mnoga.setTranslations('zh-Hant', {});
-      mnoga.setTranslations('zh', {});
+      mnoga.setPhrases('zh-Hant', {});
+      mnoga.setPhrases('zh', {});
       mnoga.setLocale('zh-Hant-HK');
       expect(mnoga.getLocale()).to.equal('zh-Hant');
     });
 
     it('falls back to language when given a tag containing script and region', () => {
-      mnoga.setTranslations('zh', {});
+      mnoga.setPhrases('zh', {});
       mnoga.setLocale('zh-Hant-HK');
       expect(mnoga.getLocale()).to.equal('zh');
     });
 
     it('falls back to language when given a tag containing script', () => {
-      mnoga.setTranslations('zh', {});
+      mnoga.setPhrases('zh', {});
       mnoga.setLocale('zh-Hant');
       expect(mnoga.getLocale()).to.equal('zh');
     });
 
     it('falls back to language when given a tag containing region', () => {
-      mnoga.setTranslations('zh', {});
+      mnoga.setPhrases('zh', {});
       mnoga.setLocale('zh-HK');
       expect(mnoga.getLocale()).to.equal('zh');
     });
 
     it('does not change order of preferences', () => {
-      mnoga.setTranslations('pt', {});
-      mnoga.setTranslations('zh', {});
+      mnoga.setPhrases('pt', {});
+      mnoga.setPhrases('zh', {});
       mnoga.setLocale(['zh-Hant-HK', 'pt', 'zh']);
       expect(mnoga.getLocale()).to.equal('pt');
     });
 
     it('tries more specific locale before attempting fallbacks', () => {
-      mnoga.setTranslations('zh-Hant', {});
-      mnoga.setTranslations('zh-Hant-TW', {});
+      mnoga.setPhrases('zh-Hant', {});
+      mnoga.setPhrases('zh-Hant-TW', {});
       mnoga.setLocale(['zh-Hant-HK', 'zh-Hant-TW']);
       expect(mnoga.getLocale()).to.equal('zh-Hant-TW');
     })
@@ -252,7 +252,7 @@ describe('Mnoga', () => {
     });
 
     it('uses alias when setting the locale', () => {
-      mnoga.setTranslations('zh-yue', {});
+      mnoga.setPhrases('zh-yue', {});
       mnoga.setAlias('zh-Hant', 'zh-yue');
       mnoga.setLocale('zh-Hant-HK');
       expect(mnoga.getLocale()).to.equal('zh-yue');
@@ -285,9 +285,9 @@ describe('Mnoga', () => {
     });
   });
 
-  describe('setTranslations', () => {
+  describe('setPhrases', () => {
     it('fails if passed a non valid locale', () => {
-      expect(() => mnoga.setTranslations(INVALID_LOCALE, {})).to.throw();
+      expect(() => mnoga.setPhrases(INVALID_LOCALE, {})).to.throw();
     });
   });
 
@@ -352,22 +352,22 @@ describe('Mnoga', () => {
     });
 
     it('uses custom fallback if provided', () => {
-      mnoga.setTranslations('zh-yue', { app: { no: { string: 'test' } } });
+      mnoga.setPhrases('zh-yue', { app: { no: { string: 'test' } } });
       expect(mnoga.t('app.no.string', {}, { fallback: 'zh-yue' }));
     });
 
     it('normalizes custom fallback', () => {
-      mnoga.setTranslations('zh-yue', { app: { no: { string: 'test' } } });
+      mnoga.setPhrases('zh-yue', { app: { no: { string: 'test' } } });
       expect(mnoga.t('app.no.string', {}, { fallback: 'ZH-YUE' }));
     });
 
     it('works without delimiters', () => {
-      mnoga.setTranslations('en', { key: 'string' });
+      mnoga.setPhrases('en', { key: 'string' });
       expect(mnoga.t('key')).to.equal('string');
     });
 
     it('works with delimiters', () => {
-      mnoga.setTranslations('en', { key: { context: 'string' } });
+      mnoga.setPhrases('en', { key: { context: 'string' } });
       expect(mnoga.t('key.context')).to.equal('string');
     });
   });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import Mnoga, { PluralCategory } from './index';
+import Mnoga from './index';
+import { PluralCategory } from './utils/pluralization';
 
 describe('Mnoga', () => {
   let mnoga: Mnoga;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,58 +1,20 @@
 import { includes } from './utils/array';
-import LanguageTag from './utils/LanguageTag';
 import {
-  PluralCategory,
-  arabic,
-  eastSlavic,
-  oneOther,
-  oneTwoOther,
-  oneUpToTwoOther,
-  oneWithZeroOther,
-  other,
-  polish,
-  westSlavic,
-} from './utils/pluralization';
-
-// Define some variables for validating keys and key context.
-const CONTEXT_CHARACTERS = '[A-Za-z0-9-_]+';
-const DELIMITER = '.';
-
-const VALID_KEY_CONTEXT = new RegExp(`^${CONTEXT_CHARACTERS}$`);
-const VALID_KEY = new RegExp(`^${CONTEXT_CHARACTERS}(${DELIMITER}${CONTEXT_CHARACTERS})*$`);
-
-// Used to find variable names inside the output string.
-const INTERPOLATION_REGEX = /%{([^}]*)}/g;
+  Aliases,
+  DEFAULT_RULES,
+  getCanonicalLocale,
+  getCanonicalLocales,
+  localeLookup,
+  Rule,
+  Rules,
+  t,
+  Translations,
+  TData,
+  VALID_KEY_CONTEXT,
+} from './utils/i18n';
 
 // Default locale is english.
 const DEFAULT_LOCALE = 'en';
-
-// Export PluralCategory so it is easy for others to create rules.
-export { PluralCategory };
-
-interface Aliases {
-  [propName: string]: string | undefined;
-}
-
-export interface Translations {
-  [propName: string]: Translations | string | undefined;
-}
-
-interface Set {
-  [propName: string]: boolean | undefined;
-};
-
-export interface Rule {
-  (n: number): PluralCategory;
-}
-
-interface Rules {
-  [propName: string]: Rule | undefined;
-}
-
-export interface TDataObject {
-  count?: number;
-  [propName: string]: string | number | undefined;
-}
 
 export interface TOptions {
   fallback?: string;
@@ -68,25 +30,9 @@ export default class Mnoga {
   private fallback: string = DEFAULT_LOCALE;
   private keyMode: boolean = false;
   private locale?: string;
-  private rules: Rules = {};
+  private rules: Rules = { ...DEFAULT_RULES };
   private subscribers: Function[] = [];
   private translations: Translations = {};
-
-  // For warnings.
-  private pluralWarning: Set = {};
-
-  constructor() {
-    // Set the default rules.
-    this.setRule('ar', arabic);
-    this.setRule(['be', 'uk', 'ru'], eastSlavic);
-    this.setRule(['af', 'de', 'el', 'en', 'es', 'fi', 'it', 'ne', 'nl', 'pt', 'sw'], oneOther);
-    this.setRule(['id', 'ja', 'ko', 'ms', 'my', 'th', 'tr', 'vi', 'zh'], other);
-    this.setRule('hi', oneWithZeroOther);
-    this.setRule('iu', oneTwoOther);
-    this.setRule('fr', oneUpToTwoOther);
-    this.setRule('pl', polish);
-    this.setRule(['cs', 'sk'], westSlavic);
-  }
 
   /**
    * Remove an alias to a locale.
@@ -135,7 +81,7 @@ export default class Mnoga {
   }
 
   public hasTranslationsForLocale(locale: string): boolean {
-    const normalizedLocale = this.normalizeLocale(locale);
+    const normalizedLocale = getCanonicalLocale(locale);
     return this.isTranslations(this.translations[normalizedLocale]);
   }
 
@@ -163,8 +109,8 @@ export default class Mnoga {
    */
   public setAlias(alias: string | string[], locale: string): void {
     // Normalize locales.
-    const aliases = this.normalizeLocales(alias);
-    const normalizedLocale = this.normalizeLocale(locale);
+    const aliases = getCanonicalLocales(alias);
+    const normalizedLocale = getCanonicalLocale(locale);
 
     // Prevent recursive behavior.
     if (normalizedLocale in this.aliases || includes(aliases, normalizedLocale)) {
@@ -202,7 +148,7 @@ export default class Mnoga {
    * @param fallback  Locale that should be used when primary locale can't be found.
    */
   public setFallback(fallback: string): void {
-    const normalized = this.normalizeLocale(fallback);
+    const normalized = getCanonicalLocale(fallback);
 
     if (this.fallback !== normalized) {
       this.fallback = normalized;
@@ -234,38 +180,8 @@ export default class Mnoga {
    * locale might be considered unavailable and will not be chosen.
    */
   public setLocale(locale: string | string[]): void {
-    // Normalize all the locales.
-    const locales: string[] = this.normalizeLocales(locale);
-
-    // If there is no match found while iterating through the list, use this one.
-    const possibleLocales: string[] = [];
-
-    // Create a new list of locales that will increase the odds of matching.
-    const baseSet: Set = {};
-
-    // Add locales to the base set.
-    locales.forEach((l) => (baseSet[l] = true));
-
-    // Create list of possible locales.
-    for (let i = 0; i < locales.length; i++) {
-      const current = locales[i];
-
-      possibleLocales.push(current);
-
-      // Create subsets of current and add them to the list of possible locales.
-      // Only add them if they aren't subsets of the next locale or if they appear later in the
-      // preference list.
-      const next = locales[i + 1] || '';
-      const subsets = this.makeSubsets(current).filter((s) => !baseSet[s] && next.search(s) === -1);
-
-      possibleLocales.push(...subsets);
-    }
-
-    const matchedLocale =
-      possibleLocales
-        // Swap any locales that have aliases with their alias.
-        .map((l) => this.aliases[l] || l)
-        .filter((l) => this.hasTranslationsForLocale(l))[0];
+    const supportedLocales = Object.keys(this.translations);
+    const matchedLocale = localeLookup(locale, supportedLocales, this.aliases);
 
     if (matchedLocale !== this.locale) {
       this.locale = matchedLocale;
@@ -281,7 +197,7 @@ export default class Mnoga {
    *                pluralization is required for a key that is using the specified locale.
    */
   public setRule(locale: string | string[], rule: Rule): void {
-    const locales: string[] = this.normalizeLocales(locale);
+    const locales: string[] = getCanonicalLocales(locale);
     const mapper = (l: string) => {
       if (rule !== this.rules[l]) {
         this.rules[l] = rule;
@@ -306,7 +222,7 @@ export default class Mnoga {
    *                      and string values are treated as translations. Other values are not valid.
    */
   public setTranslations(locale: string | string[], translations: Translations): void {
-    const locales = this.normalizeLocales(locale);
+    const locales = getCanonicalLocales(locale);
     const clonedTranslations = this.cloneTranslations(translations);
 
     locales.forEach((l) => {
@@ -340,16 +256,7 @@ export default class Mnoga {
    * @param data  Contains data to be interpolated. `count` is a magic value for pluralization.
    * @returns     Best string match for key given.
    */
-  public t(key: string, data: TDataObject = {}, options: TOptions = {}): string {
-    // If we're not in production mode, be sure the people testing
-    if (process.env.NODE_ENV !== 'production') {
-      if (!key.match(VALID_KEY)) {
-        throw new Error(
-          `${key} is not a valid key format. ` +
-          `Valid keys are of the format ${VALID_KEY.toString()}`);
-      }
-    }
-
+  public t(key: string, data: TData = {}, options: TOptions = {}): string {
     // If key mode is enabled, simply return the key.
     if (this.getKeyMode()) {
       return key;
@@ -360,50 +267,18 @@ export default class Mnoga {
     // If options has a locale, normalize it and use that instead of locale. Otherwise, check
     // if locale is even set and add that to possible locales.
     if (options.locale !== undefined) {
-      locales.push(this.normalizeLocale(options.locale));
+      locales.push(getCanonicalLocale(options.locale));
     } else if (this.locale !== undefined) {
       locales.push(this.locale);
     }
 
     if (options.fallback !== undefined) {
-      locales.push(this.normalizeLocale(options.fallback));
+      locales.push(getCanonicalLocale(options.fallback));
     } else {
       locales.push(this.fallback);
     }
 
-    // Loop through the locales and try to find an appropriate translation.
-    for (let i = 0; i < locales.length; i++) {
-      const locale = locales[i];
-      const contexts = key.split('.');
-
-      let translation: Translations[string] = this.translations[locale];
-
-      // Iterate through the contexts, getting the next value in the translations.
-      for (let j = 0; j < contexts.length; j++) {
-        const context = contexts[j];
-        translation = this.isTranslations(translation) ? translation[context] : undefined;
-      }
-
-      // If there is a count and an object comes back, check if this key is a plural context.
-      if (this.isTranslations(translation) && typeof data.count === 'number') {
-        const pluralContext: string = this.getPluralContext(locale, data.count);
-        translation = translation[pluralContext];
-      }
-
-      // If the translation is equal to string, interpolate and return.
-      if (typeof translation === 'string') {
-        return translation
-          .replace(INTERPOLATION_REGEX, (exp, arg) => {
-            const result = data[arg];
-            return typeof result === 'string' ? result :
-                   typeof result === 'number' ? `${result}` :
-                   exp;
-          });
-      }
-    }
-
-    // Fallback to the key.
-    return key;
+    return t({ data, key, locales, rules: this.rules, translations: this.translations });
   }
 
   protected callSubscribers(): void {
@@ -421,12 +296,10 @@ export default class Mnoga {
     const newTranslations = { ...translations };
 
     for(const context in newTranslations) {
-      if (process.env.NODE_ENV !== 'production') {
-        if (!context.match(VALID_KEY_CONTEXT)) {
-          throw new Error(
-            `${context} is not a valid key context. ` +
-            `Valid keys should be of the format ${VALID_KEY_CONTEXT.toString()}.`);
-        }
+      if (!context.match(VALID_KEY_CONTEXT)) {
+        throw new Error(
+          `${context} is not a valid key context. ` +
+          `Valid keys should be of the format ${VALID_KEY_CONTEXT.toString()}.`);
       }
 
       const value = newTranslations[context];
@@ -440,7 +313,7 @@ export default class Mnoga {
   }
 
   private deleteFrom(locale: string | string[], lookup: Aliases | Rules | Translations): void {
-    const locales = this.normalizeLocales(locale);
+    const locales = getCanonicalLocales(locale);
     const mapper = (l: string) => {
       if (l in lookup) {
         delete lookup[l];
@@ -457,67 +330,7 @@ export default class Mnoga {
     }
   }
 
-  /**
-   * Looks up the appropriate key context for the locale and number.
-   */
-  private getPluralContext(locale: string, count: number): PluralCategory {
-    const { language } = new LanguageTag(locale);
-    const rule = this.rules[locale] || this.rules[language];
-
-    // Since the locale may be determined by the end user's environment, do not throw an error. For
-    // better debugging purposes, though, print a warning stating that there is no rule for this
-    // locale.
-    if (rule === undefined) {
-      if (!this.pluralWarning[language]) {
-        this.pluralWarning[language] = true;
-        console.warn(`No pluralization rule found for ${locale}.`);
-      }
-    }
-
-    return rule !== undefined ? rule(count) : other();
-  }
-
   private isTranslations(translations: Translations[string]): translations is Translations {
     return typeof translations === 'object';
-  }
-
-  /**
-   * Generates viable subsets from a given locale.
-   *
-   * Examples:
-   * ```
-   * new LanguageTag('zh-Hant-HK').makeSubsets()    // ['zh-Hant', 'zh']
-   * new LanguageTag('zh-HK').makeSubsets()         // ['zh']
-   * new LanguageTag('zh-Hant').makeSubsets()       // ['zh']
-   * new LanguageTag('zh').makeSubsets()            // []
-   * ```
-   */
-  private makeSubsets(locale: string): string[] {
-    const subsets: string[] = [];
-    const languageTag = new LanguageTag(locale);
-
-    if (languageTag.hasRegion() && languageTag.hasScript()) {
-      subsets.push(`${languageTag.language}-${languageTag.script}`);
-    }
-
-    if (languageTag.language !== languageTag.toString()) {
-      subsets.push(languageTag.language);
-    }
-
-    return subsets;
-  }
-
-  private normalizeLocale(locale: string): string {
-    return new LanguageTag(locale).toString();
-  }
-
-  private normalizeLocales(locale: string | string[]): string[] {
-    if (Array.isArray(locale)) {
-      return locale.map(this.normalizeLocale);
-    } else if (!!locale) {
-      return [this.normalizeLocale(locale)];
-    } else {
-      return [];
-    }
   }
 }

--- a/src/utils/i18n.spec.ts
+++ b/src/utils/i18n.spec.ts
@@ -1,0 +1,106 @@
+import { expect } from 'chai';
+import { getCanonicalLocales, lookupLocale, lookupPhrase } from './i18n';
+import { PluralCategory } from './pluralization';
+
+describe('getCanonicalLocales', () => {
+  it('takes a single argument', () => {
+    expect(getCanonicalLocales('EN-US')).to.eql(['en-US']);
+  });
+
+  it('canonicalizes all locales', () => {
+    expect(getCanonicalLocales(['EN-US', 'ZH-HANT-TW', 'Fr'])).to.eql(['en-US', 'zh-Hant-TW', 'fr']);
+  });
+});
+
+describe('lookupLocale', () => {
+  const supportedLocales = ['zh-Hant', 'zh-Hans', 'pt', 'en'];
+
+  it('normalizes locale', () => {
+    expect(lookupLocale('ZH-hANT-hk', ['zh-Hant-HK'])).to.equal('zh-Hant-HK');
+  });
+
+  it('looks up the appropriate locale', () => {
+    expect(lookupLocale('zh-Hant-TW', supportedLocales)).to.equal('zh-Hant');
+    expect(lookupLocale('zh-Hans-CN', supportedLocales)).to.equal('zh-Hans');
+    expect(lookupLocale(['pt-BR', 'en'], supportedLocales)).to.equal('pt');
+  });
+
+  it('uses alias parameter', () => {
+    expect(lookupLocale(['zh'], supportedLocales, { zh: 'zh-Hans' })).to.equal('zh-Hans');
+  });
+
+  it('returns undefined', () => {
+    expect(lookupLocale('ja', supportedLocales)).to.equal(undefined);
+  });
+});
+
+describe('lookupPhrase', () => {
+  const phrases = {
+    en: {
+      context1: {
+        context2: 'English Phrase',
+      },
+      interpolate: '%{field1} %{field2}',
+      plural: {
+        one: 'one',
+        other: 'other',
+      },
+    },
+    ja: {
+      context1: {
+        context2: 'Japanese Phrase',
+      },
+    },
+  };
+
+  it('falls back to key', () => {
+    expect(lookupPhrase({ key: 'no-key', locales: ['pt'], phrases })).to.equal('no-key');
+  });
+
+  it('prints japanese phrase', () => {
+    const options = { key: 'context1.context2', locales: ['ja', 'en'], phrases };
+    expect(lookupPhrase(options)).to.equal('Japanese Phrase');
+  });
+
+  it('falls back to english phrase', () => {
+    const options = { key: 'context1.context2', locales: ['pt','en'], phrases };
+    expect(lookupPhrase(options)).to.equal('English Phrase');
+  });
+
+  it('uses default rules', () => {
+    const options = { data: { count: 1 }, key: 'plural', locales: ['en'], phrases };
+    expect(lookupPhrase(options)).to.equal('one');
+  });
+
+  it('uses custom rules', () => {
+    const rules = { en: () => PluralCategory.Other };
+    const options = { data: { count: 1 }, key: 'plural', locales: ['en'], phrases, rules };
+    expect(lookupPhrase(options)).to.equal('other');
+  });
+
+  it('interpolate phrase', () => {
+    const options = {
+      data: {
+        field1: 'value1',
+        field2: 'value2'
+      },
+      key: 'interpolate',
+      locales: ['en'],
+      phrases,
+    };
+    expect(lookupPhrase(options)).to.equal('value1 value2');
+  });
+
+  it('throws error when key does not match keyFormat', () => {
+    const key = 'n';
+    const keyFormat = /[^n]+/;
+    expect(() => lookupPhrase({ key, keyFormat, locales: [], phrases })).to.throw();
+  });
+
+  it('uses custom delimiter', () => {
+    const delimiter = '|';
+    const key = 'context1|context2';
+    const keyFormat = /[a-z0-9|]+/;
+    expect(lookupPhrase({ delimiter, key, keyFormat, locales: ['en'], phrases })).to.equal('English Phrase');
+  });
+});

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -1,0 +1,309 @@
+import {
+  PluralCategory,
+  arabic,
+  eastSlavic,
+  oneOther,
+  oneTwoOther,
+  oneUpToTwoOther,
+  oneWithZeroOther,
+  other,
+  polish,
+  westSlavic,
+} from './pluralization';
+import LanguageTag from './LanguageTag';
+
+/**
+ * Utility methods and interfaces that are used by Mnoga and can be used in applications that want
+ * to handle their own localization state.
+ */
+
+// Define some variables for validating keys and key context.
+const CONTEXT_CHARACTERS = '[A-Za-z0-9-_]+';
+const DELIMITER = '.';
+
+// Used to find variable names inside the output string.
+const INTERPOLATION_REGEX = /%{([^}]*)}/g;
+
+export const VALID_KEY_CONTEXT = new RegExp(`^${CONTEXT_CHARACTERS}$`);
+const VALID_KEY = new RegExp(`^${CONTEXT_CHARACTERS}(${DELIMITER}${CONTEXT_CHARACTERS})*$`);
+
+/**
+ * Aliases are a way of saying that one locale should be substituted for another locale. These
+ * should be used when a locale is not officially supported, but is preferred to fallback on a
+ * different locale. For example, `en-AU` could point to `en-GB` if we wanted Australians to see
+ * British English translations, instead of falling back to `en`.
+ */
+export interface Aliases {
+ [propName: string]: string | undefined;
+}
+
+interface Set {
+  [propName: string]: boolean | undefined;
+}
+
+export interface Translations {
+  [propName: string]: Translations | string | undefined;
+}
+
+export interface TData {
+  count?: number;
+  [propName: string]: string | number | undefined;
+}
+
+/**
+ * @param data
+ * @param delimiter
+ * @param interpolationFormat
+ * @param key
+ * @param keyFormat
+ * @param locales
+ * @param rules
+ * @param translations
+ */
+export interface TOptions {
+  data: TData;
+  delimiter?: string;
+  interpolationFormat?: RegExp;
+  key: string;
+  keyFormat?: RegExp;
+  locales: string[];
+  rules?: Rules;
+  translations: Translations;
+}
+
+export interface Rule {
+  (n: number): PluralCategory;
+}
+
+export interface Rules {
+  [propName: string]: Rule | undefined;
+}
+
+// The rules that will be used if no rules are specified.
+export const DEFAULT_RULES: Rules = Object.freeze({
+  af: oneOther,
+  ar: arabic,
+  be: eastSlavic,
+  cs: westSlavic,
+  de: oneOther,
+  el: oneOther,
+  en: oneOther,
+  es: oneOther,
+  fi: oneOther,
+  fr: oneUpToTwoOther,
+  hi: oneWithZeroOther,
+  id: other,
+  it: oneOther,
+  iu: oneTwoOther,
+  ja: other,
+  ko: other,
+  ms: other,
+  my: other,
+  ne: oneOther,
+  nl: oneOther,
+  pl: polish,
+  pt: oneOther,
+  th: other,
+  tr: other,
+  sk: westSlavic,
+  sw: oneOther,
+  uk: eastSlavic,
+  ru: eastSlavic,
+  vi: other,
+  zh: other,
+});
+
+/**
+ * Performs a locale lookup for a single best locale. This performs quite similarly to
+ * RFC documentation on looking up locales: https://tools.ietf.org/html/rfc4647#section-3.4.
+ *
+ * @param preferredLocales  User locales or environment locales, ordered by preference.
+ * @param supportedLocales  Locales that the application supports.
+ * @param aliases           Locales that are not officially supported, but can be substituted if
+ *                          available.
+ * @returns                 The first locale that exactly matches or has a subset that matches.
+ *                          Results can be undefined if no match is found.
+ */
+export function localeLookup(
+  preferredLocales: string | string[],
+  supportedLocales: string[],
+  aliases?: Aliases
+): string | undefined {
+  // Normalize all the locales.
+  const normalizedPreferredlocales = getCanonicalLocales(preferredLocales);
+  const supportedSet: Set = {};
+
+  getCanonicalLocales(supportedLocales).forEach((l) => (supportedSet[l] = true));
+
+  // Normalize aliases.
+  const normalizedAliases: Aliases = {};
+
+  if (isAlias(aliases)) {
+    for (let key in aliases) {
+      const value = aliases[key];
+
+      if (typeof value === 'string') {
+        const canonicalLocale = getCanonicalLocale(key);
+        normalizedAliases[canonicalLocale] = getCanonicalLocale(value);
+      }
+    }
+  }
+
+  // Since aliases may or may not be normalized,
+  // If there is no match found while iterating through the list, use this one.
+  const possibleLocales: string[] = [];
+
+  // Create a new list of locales that will increase the odds of matching.
+  const baseSet: Set = {};
+
+  // Add locales to the base set.
+  normalizedPreferredlocales.forEach((l) => (baseSet[l] = true));
+
+  // Create list of possible locales.
+  for (let i = 0; i < normalizedPreferredlocales.length; i++) {
+    const current = normalizedPreferredlocales[i];
+
+    possibleLocales.push(current);
+
+    // Create subsets of current and add them to the list of possible locales.
+    // Only add them if they aren't subsets of the next locale or if they appear later in the
+    // preference list.
+    const next = normalizedPreferredlocales[i + 1] || '';
+    const subsets = makeSubsets(current).filter((s) => !baseSet[s] && next.search(s) === -1);
+
+    possibleLocales.push(...subsets);
+  }
+
+  const matchedLocales =
+    possibleLocales
+      // Swap any locales that have aliases with their alias.
+      .map((l) => {
+        const alias = normalizedAliases[l];
+        return typeof alias === 'string' ? alias : l;
+      })
+      // Filter for a locale that is in the supported set.
+      .filter((l) => supportedSet[l] === true);
+
+  // Return the first locale that matched (or undefined if it is not available).
+  return matchedLocales[0];
+}
+
+function isAlias(aliases: Aliases | undefined): aliases is Aliases {
+  return typeof aliases === 'object';
+}
+
+function isTranslations(translations: Translations[string]): translations is Translations {
+  return typeof translations === 'object';
+}
+
+/**
+ * Generates viable subsets from a given locale.
+ *
+ * Examples:
+ * ```
+ * new LanguageTag('zh-Hant-HK').makeSubsets()    // ['zh-Hant', 'zh']
+ * new LanguageTag('zh-HK').makeSubsets()         // ['zh']
+ * new LanguageTag('zh-Hant').makeSubsets()       // ['zh']
+ * new LanguageTag('zh').makeSubsets()            // []
+ * ```
+ */
+function makeSubsets(locale: string): string[] {
+  const subsets: string[] = [];
+  const languageTag = new LanguageTag(locale);
+
+  if (languageTag.hasRegion() && languageTag.hasScript()) {
+    subsets.push(`${languageTag.language}-${languageTag.script}`);
+  }
+
+  if (languageTag.language !== languageTag.toString()) {
+    subsets.push(languageTag.language);
+  }
+
+  return subsets;
+}
+
+/**
+ * Canonicalize a single locale.
+ */
+export function getCanonicalLocale(locale: string): string {
+  return LanguageTag.toString(locale);
+}
+
+/**
+ * Returns an array of canonicalized locales. This method does what the specification for
+ * Intl.getCanonicalLocales does.
+ *
+ * ```
+ * getCanonicalLocales('EN-US'); // ["en-US"]
+ * getCanonicalLocales(['EN-US', 'Fr']); // ["en-US", "fr"]
+ * ```
+ */
+export function getCanonicalLocales(locales: string | string[]): string[] {
+  if (typeof locales === 'string') {
+    return [getCanonicalLocale(locales)];
+  } else {
+    return locales.map(getCanonicalLocale);
+  }
+}
+
+/**
+ * Look up a translation with the given key and locales.
+ *
+ * NOTE: Locales that are passed into this method are not normalized. It is important do this if
+ * the list of locales are arbitrary (for example, an end users browser). Look into using
+ * `getCanonicalLocales` on locales, rule keys and translation keys.
+ */
+export function t(options: TOptions): string {
+  const {
+    data = {},
+    delimiter = DELIMITER,
+    interpolationFormat = INTERPOLATION_REGEX,
+    key = '',
+    keyFormat = VALID_KEY,
+    locales = [],
+    rules = DEFAULT_RULES,
+    translations = {},
+  } = options;
+
+  // If the key is a not valid (or not even a string), throw an error.
+  if (!key.match(keyFormat)) {
+    throw new Error(
+      `${key} is not a valid key format. ` +
+      `Valid keys are of the format ${keyFormat.toString()}`);
+  }
+
+  // Loop through the locales and try to find an appropriate translation.
+  for (let i = 0; i < locales.length; i++) {
+    const locale = locales[i];
+    const contexts = key.split(delimiter);
+
+    let translation: Translations[string] = translations[locale];
+
+    // Iterate through the contexts, getting the next value in the translations.
+    for (let j = 0; j < contexts.length; j++) {
+      const context = contexts[j];
+      translation = isTranslations(translation) ? translation[context] : undefined;
+    }
+
+    // If there is a count and an object comes back, check if this key is a plural context.
+    if (isTranslations(translation) && typeof data.count === 'number') {
+      const rule: Rule = rules[locale] || other;
+      const context = rule(data.count);
+      translation = translation[context];
+    }
+
+    // If the translation is equal to string, interpolate and return.
+    if (typeof translation === 'string') {
+      return translation
+        .replace(interpolationFormat, (exp, arg) => {
+          const result = data[arg];
+          return typeof result === 'string' ? result :
+                 typeof result === 'number' ? `${result}` :
+                 exp;
+        });
+    }
+  }
+
+  // Fallback to the key.
+  return key;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,12 +10,10 @@
     "strictNullChecks": true,
     "target": "ES5",
     "types": [
-      "env",
       "mocha"
     ],
     "typeRoots": [
-      "node_modules/@types",
-      "typings"
+      "node_modules/@types"
     ]
   },
   "include": [

--- a/typings/env/index.d.ts
+++ b/typings/env/index.d.ts
@@ -1,3 +1,0 @@
-declare namespace process.env {
-  let NODE_ENV: string;
-}


### PR DESCRIPTION
Moving localization utilities to a new folder. I'm not 100% sure if this is a good idea or not. The reason having the class is so nice is that it normalizes everything for you and it can do it efficiently. Normalizing with utility methods is kind of difficult. 

We could either change the utility methods to never normalize or normalize in certain instances (which I am currently doing). Since the `t` is called so often, I'd like to simply state in the docs that it will never happen and it's up to the user to do this.

Something else to note is that immutable data structures are not supported. I would be in favor of supporting them if all of our methods returned primitive types. But, that is not the case. Thoughts?