### PR TITLE
Make sure subscribers don't change while iterating over them.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -407,7 +407,10 @@ export default class Mnoga {
   }
 
   protected callSubscribers(): void {
-    this.subscribers.map((subscriber) => subscriber());
+    // Make a copy of the subscribers before iterating over them in case one of the subscribers
+    // triggers a call to `this.subscribe`.
+    const currentSubscribers = this.subscribers.slice();
+    currentSubscribers.forEach((subscriber) => subscriber());
   }
 
   /**


### PR DESCRIPTION
This makes `callSubscribers` consistent with how `EventEmitter.prototype.emit` and Redux's
`dispatch` work.

Also use `forEach` instead of `map`, since the result is not used.